### PR TITLE
Add pattern validation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,9 @@ addNewaddresses(model: UserAddressDto | null = null): FormGroup<any> {
 ---
 
 ```
-### What Is New?  
+### What Is New?
+#### Version 1.0.69
+   - Added support for the OpenAPI `pattern` property. Generated controls now include `Validators.pattern` when a schema defines a regex.
 #### Version 1.0.64
    - Fix generated enum keys (Git Hub: Issue #8)
 #### Version 1.0.64

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "commonjs",
   "name": "angular-formsbuilder-gen",
-  "version": "1.0.68",
+  "version": "1.0.69",
   "main": "index.js",
   "keywords": [
     "angular",

--- a/src/Builders/PermitiveType.ts
+++ b/src/Builders/PermitiveType.ts
@@ -13,10 +13,12 @@ export class PermitiveType implements ITypeBuilder {
             validations.push('Validators.required');
 
         if (prop.type == IDataType.string) {
-            if (prop.minLength) 
+            if (prop.minLength)
                 validations.push(`Validators.minLength(${prop.minLength})`)
             if (prop.maxLength)
                 validations.push(`Validators.maxLength(${prop.maxLength})`)
+            if (prop.pattern)
+                validations.push(`Validators.pattern(${JSON.stringify(prop.pattern)})`)
         }
 
         if (prop.type == IDataType.integer || prop.type == IDataType.number) {


### PR DESCRIPTION
## Summary
- support regex `pattern` validation in generated form builders
- document pattern support in README
- bump version to 1.0.69

## Testing
- `npx tsc` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68527d6a05408327884f92591ccf2ef9